### PR TITLE
making the table under Status more responsive

### DIFF
--- a/app/src/assets/css/main-style.css
+++ b/app/src/assets/css/main-style.css
@@ -604,7 +604,7 @@ button.active, button:hover, button:focus, .link-button.active, .link-button:hov
 .recipe-body {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: left;
   align-items: stretch;
   overflow-y: hidden;
 }
@@ -889,6 +889,11 @@ settings-layout {
 .status td {
   padding: 1rem;
 }
+
+table td:nth-child(3) {
+  word-break: break-all;
+}
+
 
 @media only screen and (max-width: 1394px) {
   .header-wrapper .header {


### PR DESCRIPTION
This fixes the Settings page getting behind the left sidebar and making the status table more responsive by breaking the text in the third column.